### PR TITLE
feat: allow grafikart discord link

### DIFF
--- a/src/filters/InviteFilter.ts
+++ b/src/filters/InviteFilter.ts
@@ -15,6 +15,7 @@ export default class InviteFilter implements IFilter {
 
   filter (message: Message): boolean {
     if (message.content.match(/(discord\.(gg|io|me|li)|discordapp\.com\/(invite|oauth2))\/[0-9A-Za-z]+/i) !== null) {
+      if (message.content.match(/(discord\.(gg|io|me|li)|discordapp\.com\/(invite|oauth2))\/rAuuD7Q/i)) return false
       this.muteCommand
         .muteMember(message.member, 'Les liens d\'invitation discord sont interdit sur ce serveur')
         .then(function () {

--- a/test/filters/InviteFilter.test.ts
+++ b/test/filters/InviteFilter.test.ts
@@ -22,13 +22,16 @@ describe('InviteFilter', () => {
 
   it('détecte les invitation discord', () => {
     expect(filter.filter(fakeMessage('Pour ce qui veulent mon groupe : https://discord.gg/jMwPGe'))).to.be.true
-    expect(filter.filter(fakeMessage('Pour ce qui veulent mon groupe : https://discordapp.com/invite/rAuuD7Q'))).to.be.true
     expect(filter.filter(fakeMessage(`Pour ce qui veulent mon groupe : 
     
     https://discord.gg/jMwPGe`))).to.be.true
     expect(filter.filter(fakeMessage('notre bot prevention: https://discordapp.com/oauth2/authorize?client_id=579748008804089891&scope=bot&permissions=252928'))).to.be.true
     expect(filter.filter(fakeMessage('Notre bot Anti-Raid: https://discordapp.com/oauth2/authorize?client_id=451361230901346314&scope=bot&permissions=8'))).to.be.true
     expect(filter.filter(fakeMessage('Un message à propos de discord'))).to.be.false
+  })
+
+  it('détecte l\'invitation discord du serveur grafikart', () => {
+    expect(filter.filter(fakeMessage('Pour ce qui veulent mon groupe : https://discordapp.com/invite/rAuuD7Q'))).to.be.false
   })
 
   it('mute l\'utilisateur', () => {


### PR DESCRIPTION
Basically avoid this problem :

![preview](https://i.imgur.com/2MR05RE.png)

It only allows this link https://discordapp.com/invite/rAuuD7Q (return `false` when it's matched)

Added a test which expect `Pour ce qui veulent mon groupe : https://discordapp.com/invite/rAuuD7Q` to be `false` and not `true` like it was before.

But maybe it was intentional because you wrote it in the test :

```js
expect(filter.filter(fakeMessage('Pour ce qui veulent mon groupe : https://discordapp.com/invite/rAuuD7Q'))).to.be.true
```